### PR TITLE
Add client and server script

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,56 @@
+on:
+  pull_request: ~
+  push:
+    branch: main
+    tags: "v*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ${{ github.repository }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: set up qemu
+        uses: docker/setup-qemu-action@v2
+      - name: set up buildx
+        uses: docker/setup-buildx-action@v2
+      - name: log in to registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: extract tags
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+      - name: build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  release:
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    permissions:
+      contents: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            docker-credential-oidc

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,5 @@ from python:3
 WORKDIR /app
 COPY ./server.py ./server.py
 
+STOPSIGNAL SIGTERM
 ENTRYPOINT ["python3", "./server.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+from python:3
+
+WORKDIR /app
+COPY ./server.py ./server.py
+
+ENTRYPOINT ["python3", "./server.py"]

--- a/docker-credential-oidc
+++ b/docker-credential-oidc
@@ -5,13 +5,16 @@ import ssl
 import secrets
 import hashlib
 import webbrowser
+import json
 from base64 import urlsafe_b64encode
-from typing import NamedTuple
-from threading import Thread, Event
+from functools import cached_property
+from dataclasses import dataclass
+from threading import Thread
+from queue import Queue
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from urllib.request import urlopen
 from urllib.error import HTTPError
-from urllib.parse import urlparse, urlunparse, urlencode
+from urllib.parse import urlparse, urlunparse, urlencode, parse_qs
 
 ssl_ctx = ssl.create_default_context()
 
@@ -26,7 +29,8 @@ def parse_prefix(s, prefix):
     return s[len(prefix):]
 
 
-class AuthInfo(NamedTuple):
+@dataclass
+class AuthInfo:
     realm: str
     service: str
     scope: str | None = None
@@ -47,25 +51,27 @@ class AuthInfo(NamedTuple):
         kwargs = {k: v.strip('"') for k, v in (c.split("=", maxsplit=1) for c in challenges)}
         return cls(**kwargs)
 
-
-    def auth_url(self, redirect, challenge):
+    @cached_property
+    def openid_configuration(self):
         realm = urlparse(self.realm)
         path, _ = realm.path.rsplit("/", maxsplit=1)
-        query = {
-            'client_id': 'docker',
-            'response_type': 'code',
-            'redirect_uri': redirect,
-            'code_challenge': challenge,
-            'code_challenge_method': "S256",
-        }
-        url = realm._replace(path="/".join([path, "auth"]), query=urlencode(query))
-        return urlunparse(url)
+        url = realm._replace(path="/".join([path, ".well-known", "openid-configuration"]))
+        with urlopen(urlunparse(url), context=ssl_ctx) as f:
+            return json.load(f)
+
+    @property
+    def auth_url(self):
+        return urlparse(self.openid_configuration["authorization_endpoint"])
+
+    @property
+    def token_url(self):
+        return urlparse(self.openid_configuration["token_endpoint"])
 
 
 class Server(HTTPServer):
-    def __init__(self, payload, event, *args, **kwargs):
+    def __init__(self, payload, queue, *args, **kwargs):
         self.payload = payload
-        self.event = event
+        self.queue = queue
         self.code_verifier = secrets.token_urlsafe(32).encode().rstrip(b"=")
         self.code_challenge = urlsafe_b64encode(hashlib.sha256(self.code_verifier).digest()).rstrip(b"=")
         super().__init__(*args, **kwargs)
@@ -74,19 +80,40 @@ class Server(HTTPServer):
 class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
         path = urlparse(self.path)
+        redirect = f"http://localhost:{self.server.server_port}/callback"
+
         if path.path == "/start":
             self.send_response(302)
-            redirect = f"http://{self.server.server_address[0]}:{self.server.server_address[1]}/callback"
-            self.send_header("Location", self.server.payload.auth_url(redirect, self.server.code_challenge))
+            query = {
+                'client_id': self.server.payload.service,
+                'response_type': 'code',
+                'redirect_uri': redirect,
+                'code_challenge': self.server.code_challenge,
+                'code_challenge_method': "S256",
+            }
+            url = self.server.payload.auth_url._replace(query=urlencode(query))
+            self.send_header("Location", urlunparse(url))
             self.end_headers()
         elif path.path == "/callback":
+            query = parse_qs(path.query)
+            [code] = query["code"]
+
+            data = urlencode({
+                'client_id': self.server.payload.service,
+                'code': code,
+                'code_verifier': self.server.code_verifier,
+                'grant_type': 'authorization_code',
+                'redirect_uri': redirect,
+            }).encode()
+
+            with urlopen(urlunparse(self.server.payload.token_url), data=data, context=ssl_ctx) as f:
+                token = json.loads(f.read())
+
             self.send_response(200)
             self.end_headers()
             self.wfile.write(f"Successfully authenticated to {self.server.payload}! You may close this window.".encode())
-            query = parse_qs(path.query)
-            [code] = query["code"]
-            [state] = query["session_state"]
-            self.server.event.set()
+
+            self.server.queue.put(token)
         else:
             raise ValueError(f"Unrecognized path: {path}")
 
@@ -94,24 +121,26 @@ class Handler(BaseHTTPRequestHandler):
         return
 
 
-def main(argv=None):
+def main(argv=None) -> int:
     if argv is None:
         argv = sys.argv[1:]
 
     if argv[0] != "get":
         raise RuntimeError(f"Unsupported operation {argv[1]}, expected 'get'")
     payload = sys.stdin.read().rstrip("\n")
-
     auth_info = AuthInfo.for_registry(payload)
-    event = Event()
-    httpd = Server(auth_info, event, ('localhost', 8000), Handler)
+
+    queue = Queue()
+    httpd = Server(auth_info, queue, ('localhost', 8000), Handler)
 
     t = Thread(target=httpd.serve_forever)
     t.start()
-    webbrowser.open(f"http://{httpd.server_address[0]}:{httpd.server_address[1]}/start")
-    event.wait()
+    webbrowser.open(f"http://localhost:{httpd.server_port}/start")
+    auth = queue.get()
     httpd.shutdown()
     t.join()
+    json.dump({"ServerURL": payload, "Username": "OIDC", "Secret": auth["access_token"]}, sys.stdout)
+    return 0
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/docker-credential-oidc
+++ b/docker-credential-oidc
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+import sys
+import ssl
+import secrets
+import hashlib
+import webbrowser
+from base64 import urlsafe_b64encode
+from typing import NamedTuple
+from threading import Thread, Event
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from urllib.request import urlopen
+from urllib.error import HTTPError
+from urllib.parse import urlparse, urlunparse, urlencode
+
+ssl_ctx = ssl.create_default_context()
+
+# FIXME: This is for testing, remove
+ssl_ctx.check_hostname = False
+ssl_ctx.verify_mode = ssl.CERT_NONE
+
+
+def parse_prefix(s, prefix):
+    if not s.startswith(prefix):
+        raise ValueError(f"Expected string starting with {prefix}, got {s}")
+    return s[len(prefix):]
+
+
+class AuthInfo(NamedTuple):
+    realm: str
+    service: str
+    scope: str | None = None
+
+    @classmethod
+    def for_registry(cls, registry):
+        try:
+            f = urlopen(f"https://{registry}/v2/", context=ssl_ctx)
+        except HTTPError as e:
+            if e.code != 401:
+                raise e
+            auth = e.headers["www-authenticate"]
+        else:
+            raise RuntimeError(f"Got {f.code} response, expected 401")
+
+        auth = parse_prefix(auth, "Bearer ")
+        challenges = auth.split(",")
+        kwargs = {k: v.strip('"') for k, v in (c.split("=", maxsplit=1) for c in challenges)}
+        return cls(**kwargs)
+
+
+    def auth_url(self, redirect, challenge):
+        realm = urlparse(self.realm)
+        path, _ = realm.path.rsplit("/", maxsplit=1)
+        query = {
+            'client_id': 'docker',
+            'response_type': 'code',
+            'redirect_uri': redirect,
+            'code_challenge': challenge,
+            'code_challenge_method': "S256",
+        }
+        url = realm._replace(path="/".join([path, "auth"]), query=urlencode(query))
+        return urlunparse(url)
+
+
+class Server(HTTPServer):
+    def __init__(self, payload, event, *args, **kwargs):
+        self.payload = payload
+        self.event = event
+        self.code_verifier = secrets.token_urlsafe(32).encode().rstrip(b"=")
+        self.code_challenge = urlsafe_b64encode(hashlib.sha256(self.code_verifier).digest()).rstrip(b"=")
+        super().__init__(*args, **kwargs)
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        path = urlparse(self.path)
+        if path.path == "/start":
+            self.send_response(302)
+            redirect = f"http://{self.server.server_address[0]}:{self.server.server_address[1]}/callback"
+            self.send_header("Location", self.server.payload.auth_url(redirect, self.server.code_challenge))
+            self.end_headers()
+        elif path.path == "/callback":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(f"Successfully authenticated to {self.server.payload}! You may close this window.".encode())
+            query = parse_qs(path.query)
+            [code] = query["code"]
+            [state] = query["session_state"]
+            self.server.event.set()
+        else:
+            raise ValueError(f"Unrecognized path: {path}")
+
+    def log_message(self, *args, **kwargs):
+        return
+
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+
+    if argv[0] != "get":
+        raise RuntimeError(f"Unsupported operation {argv[1]}, expected 'get'")
+    payload = sys.stdin.read().rstrip("\n")
+
+    auth_info = AuthInfo.for_registry(payload)
+    event = Event()
+    httpd = Server(auth_info, event, ('localhost', 8000), Handler)
+
+    t = Thread(target=httpd.serve_forever)
+    t.start()
+    webbrowser.open(f"http://{httpd.server_address[0]}:{httpd.server_address[1]}/start")
+    event.wait()
+    httpd.shutdown()
+    t.join()
+
+if __name__ == "__main__":
+    main()

--- a/server.py
+++ b/server.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import sys
+from argparse import ArgumentParser
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+
+class Server(HTTPServer):
+    def __init__(self, upstream: str, *args, **kwargs):
+        self.upstream = upstream
+        super().__init__(*args, **kwargs)
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write("Hello, world!".encode())
+
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+
+    parser = ArgumentParser()
+    parser.add_argument("upstream", type=str)
+    args = parser.parse_args(argv)
+
+    httpd = Server(args.upstream, ('', 80), Handler)
+    httpd.serve_forever()
+
+if __name__ == "__main__":
+    main()

--- a/server.py
+++ b/server.py
@@ -1,21 +1,48 @@
 #!/usr/bin/env python3
 
+import json
+import signal
+import ssl
 import sys
+from threading import Thread
 from argparse import ArgumentParser
+from functools import cached_property
 from http.server import HTTPServer, BaseHTTPRequestHandler
+from urllib.parse import urlparse, urlunparse
+from urllib.request import urlopen
+
+
+ssl_ctx = ssl.create_default_context()
+
+# FIXME: This is for testing, remove
+ssl_ctx.check_hostname = False
+ssl_ctx.verify_mode = ssl.CERT_NONE
 
 
 class Server(HTTPServer):
-    def __init__(self, upstream: str, *args, **kwargs):
-        self.upstream = upstream
+    def __init__(self, realm: str, *args, **kwargs):
+        self.realm = urlparse(realm)
         super().__init__(*args, **kwargs)
 
 
 class Handler(BaseHTTPRequestHandler):
+    def do_HEAD(self):
+        self.log_message("HEAD %s %s", self.path, self.headers)
+
+    def do_POST(self):
+        self.log_message("POST %s %s", self.path, self.headers)
+
     def do_GET(self):
-        self.send_response(200)
-        self.end_headers()
-        self.wfile.write("Hello, world!".encode())
+        path = urlparse(self.path)
+        if path.path == "/auth/.well-known/openid-configuration":
+            self.send_response(303)
+            redirect = self.server.realm._replace(
+                path="/".join([self.server.realm.path, ".well-known", "openid-configuration"])
+            )
+            self.send_header("Location", urlunparse(redirect))
+            self.end_headers()
+        else:
+            self.log_message("GET %s %s", self.path, self.headers)
 
 
 def main(argv=None):
@@ -23,11 +50,15 @@ def main(argv=None):
         argv = sys.argv[1:]
 
     parser = ArgumentParser()
-    parser.add_argument("upstream", type=str)
+    parser.add_argument("realm", type=str)
     args = parser.parse_args(argv)
 
-    httpd = Server(args.upstream, ('', 80), Handler)
-    httpd.serve_forever()
+    httpd = Server(args.realm, ('', 80), Handler)
+    signal.signal(signal.SIGTERM, lambda *args: httpd.shutdown())
+
+    t = Thread(target=httpd.serve_forever)
+    t.start()
+    t.join()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This is the initial implementation of the credential helper. It does not cache tokens, so the token must be refreshed on every authentication.

Also, only the latest (`3.0.0-alpha.1`) release of `registry` seems to support JWKS files properly.