### PR TITLE
Fix hang on cross-compiled system

### DIFF
--- a/.github/workflows/build-client.yaml
+++ b/.github/workflows/build-client.yaml
@@ -71,8 +71,8 @@ jobs:
       - name: build
         run: |
           cargo build --release --target x86_64-unknown-linux-gnu
-          PKG_CONFIG_SYSROOT_DIR=/usr/aarch64-linux-gnu PKG_CONFIG_DIR=/usr/aarch64-linux-gnu/lib/pkgconfig \
-            cargo build --release --target aarch64-unknown-linux-gnu --config target.aarch64-unknown-linux-gnu.linker=\"aarch64-linux-gnu-ld\"
+          PKG_CONFIG_SYSROOT_DIR="" PKG_CONFIG_DIR=/usr/lib/aarch64-linux-gnu/pkgconfig \
+            cargo build --release --target aarch64-unknown-linux-gnu --config target.aarch64-unknown-linux-gnu.linker=\"aarch64-linux-gnu-gcc\"
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
When deploying the cross-compiled build to a Hetzner arm64 machine, it hangs. The only reference to a similar issue I've been able to find is [here](https://users.rust-lang.org/t/cross-compiled-hello-world-hangs-on-aarch64/56321/3).

The fix was to unset `PKG_CONFIG_SYSROOT_DIR`, as suggested [here](https://felix-knorr.net/posts/2023-01-11-cross-compiling-rust.html).